### PR TITLE
[WEB-1842] - implements /api/v1/admin/candidates/mass-crm-companies-refresh endpoint

### DIFF
--- a/api/controllers/admin/mass-crm-companies-refresh.js
+++ b/api/controllers/admin/mass-crm-companies-refresh.js
@@ -1,11 +1,10 @@
-const { getCRMCompanyObject } = require('../../util/get-crm-company-object');
 const hubspot = require('@hubspot/api-client');
 const hubSpotToken =
   sails.config.custom.hubSpotToken || sails.config.hubSpotToken;
 
 const generateCompanyProperties = (fields) => async (campaign) => {
   const id = campaign.data?.hubspotId;
-  const companyObject = await getCRMCompanyObject(campaign);
+  const companyObject = await sails.helpers.crm.getCrmCompanyObject(campaign);
   const properties = fields.reduce(
     (aggregate, field) => ({
       ...aggregate,

--- a/api/controllers/admin/mass-crm-companies-refresh.js
+++ b/api/controllers/admin/mass-crm-companies-refresh.js
@@ -1,0 +1,83 @@
+const { getCRMCompanyObject } = require('../../util/get-crm-company-object');
+const hubspot = require('@hubspot/api-client');
+const hubSpotToken =
+  sails.config.custom.hubSpotToken || sails.config.hubSpotToken;
+
+module.exports = {
+  friendlyName: 'Mass CRM Companies Refresh',
+
+  description: 'Admin-only endpoint for refreshing specific fields on all CRM companies.',
+
+  inputs: {
+    fields: {
+      type: 'ref',
+      description: 'Array of field names to update on Companies in the crm for each campaign object. Send `["all"]` w/o any other fields to update all fields.',
+    },
+  },
+
+  exits: {
+    success: {
+      description: 'OK',
+    },
+
+    badRequest: {
+      description: 'Error refreshing CRM companies',
+      responseType: 'badRequest',
+    },
+  },
+
+  fn: async function(inputs, exits) {
+    try {
+      const {fields} = inputs;
+      const campaigns = await Campaign.find();
+      const existingCRMCompanies = campaigns.filter(({data}) => data?.hubspotId);
+
+      const companyUpdateObjects = await Promise.all(
+        existingCRMCompanies.map(
+          async campaign => {
+            const id = campaign.data?.hubspotId;
+            const companyObject = await getCRMCompanyObject(campaign);
+            return fields.reduce(
+              (aggregate, field) => {
+                return {
+                  ...aggregate,
+                  properties: {
+                    ...aggregate.properties,
+                    ...(
+                      companyObject.properties[field] || companyObject.properties[field] === null ?
+                        {[field]: companyObject.properties[field]} : {}
+                    )
+                  }
+                };
+              }, {id, properties: {}}
+            );
+          }
+        )
+      );
+    } catch (e) {
+      console.error(e);
+      return exits.badRequest({
+        message: 'Error getting users',
+      });
+    }
+
+    const hubspotClient = new hubspot.Client({ accessToken: hubSpotToken });
+
+
+    let updates;
+    try {
+      updates = await hubspotClient.crm.companies.batchApi.update({
+        inputs: companyUpdateObjects,
+      });
+    } catch (e) {
+      console.log('error updating crm', e);
+      await sails.helpers.slack.errorLoggerHelper(
+          `Error updating companies in hubspot`,
+          e,
+      );
+    }
+
+    return exits.success(`OK: ${updates?.results?.length} companies updated`);
+
+  },
+};

--- a/api/controllers/campaign/onboarding/update.js
+++ b/api/controllers/campaign/onboarding/update.js
@@ -49,7 +49,6 @@ module.exports = {
       }
 
       // setting last_step_date for the crm
-      // moment().format('YYYY-MM-DD'),
       if (campaign.currentStep !== existing?.data?.currentStep) {
         campaign.lastStepDate = moment().format('YYYY-MM-DD');
       }

--- a/api/helpers/crm/associate-user-campaign.js
+++ b/api/helpers/crm/associate-user-campaign.js
@@ -54,7 +54,6 @@ module.exports = {
         // it would be smart if this returned an id instead of a success message.
         await sails.helpers.crm.updateUser(user);
         // make sure we pull the latest user object with the hubspotId.
-        // console.log('refreshing user', user.id);
         user = await User.findOne({ id: user.id });
         if (user.metaData) {
           const metaData = JSON.parse(user.metaData);

--- a/api/helpers/crm/get-crm-company-object.js
+++ b/api/helpers/crm/get-crm-company-object.js
@@ -15,7 +15,8 @@ const determineName = async (data, campaignUserId) => {
   return await sails.helpers.user.name(user)
 }
 
-const getCRMCompanyObject = async (campaign) => {
+const getCrmCompanyObject = async (inputs, exits) => {
+  const { campaign } = inputs;
   const { data, isActive, isVerified, dateVerified, isPro } = campaign || {};
   const {
     lastStepDate,
@@ -61,7 +62,7 @@ const getCRMCompanyObject = async (campaign) => {
   const formattedDate = dateVerified !== null ?
     moment(new Date(dateVerified)).format('YYYY-MM-DD') : null
 
-  return {
+  exits.success({
     properties: {
       name,
       candidate_party: party,
@@ -104,9 +105,21 @@ const getCRMCompanyObject = async (campaign) => {
       ...(ballotLevel ? { office_level: ballotLevel } : {}),
       ...(runForOffice ? { running: runForOffice } : {})
     },
-  }
+  })
 }
 
 module.exports = {
-  getCRMCompanyObject
+  inputs: {
+    campaign: {
+      type: 'ref',
+      description: 'The campaign object to generate a CRM company object for',
+      required: true
+    }
+  },
+  exits: {
+    success: {
+      description: 'Successfully generated CRM company object',
+    }
+  },
+  fn: getCrmCompanyObject
 }

--- a/api/helpers/crm/update-campaign.js
+++ b/api/helpers/crm/update-campaign.js
@@ -1,6 +1,5 @@
 // https://developers.hubspot.com/docs/api/crm/companies
 const hubspot = require('@hubspot/api-client');
-const { getCRMCompanyObject } = require('../../util/get-crm-company-object');
 
 const hubSpotToken =
   sails.config.custom.hubSpotToken || sails.config.hubSpotToken;
@@ -37,7 +36,7 @@ module.exports = {
       const hubspotClient = new hubspot.Client({ accessToken: hubSpotToken });
       const { campaign } = inputs;
       const { data } = campaign || {};
-      const companyObj = await getCRMCompanyObject(campaign);
+      const companyObj = await sails.helpers.crm.getCrmCompanyObject(campaign);
       const name = companyObj.properties.name
 
       const existingId = data.hubspotId;

--- a/api/helpers/crm/update-user.js
+++ b/api/helpers/crm/update-user.js
@@ -38,22 +38,6 @@ module.exports = {
       const { user, loginEvent, updateEvent } = inputs;
       const { id, firstName, lastName, email, phone, uuid, zip } = user;
 
-      // const userCrew = await User.findOne({ id }).populate('crew');
-      // const crew = userCrew.crew;
-      // crew.sort((a, b) => b.id - a.id);
-      // const applicationApproved = await Application.count({
-      //   user: id,
-      //   status: 'approved',
-      // });
-      // const applicationDeclined = await Application.count({
-      //   user: id,
-      //   status: 'rejected',
-      // });
-      // const applicationSubmitted = await Application.find({
-      //   user: id,
-      //   status: 'in review',
-      // });
-
       const campaigns = await Campaign.find({
         user: id,
       });
@@ -68,17 +52,11 @@ module.exports = {
           lastname: lastName,
           email,
           phone,
-          // type: applicationApproved > 0 ? 'Campaign' : 'User',
           type: campaign ? 'Campaign' : 'User',
           lifecyclestage: campaign ? 'customer' : 'opportunity',
           active_candidate: campaign ? 'Yes' : 'No',
           live_candidate: campaign && campaign?.launchStatus === 'launched',
           source: 'Good Party Site',
-          // all_endorsements: allEndorsements,
-          // recent_endorsement:
-          //   supports.length > 0
-          //     ? `${supports[0].candidate.firstName} ${supports[0].candidate.lastName}`
-          //     : '',
           zip,
           referral_link: `https://goodparty.org/?u=${uuid}`,
         },
@@ -94,6 +72,7 @@ module.exports = {
 
       let contactId;
       let profile_updated_count = 0;
+      console.dir(user, {colors: true, depth: 4})
       if (user.metaData) {
         const metaData = JSON.parse(user.metaData);
         if (metaData.hubspotId) {
@@ -119,7 +98,6 @@ module.exports = {
       }
 
       if (!contactId) {
-        // console.log('getting hubspotId for user', email);
         try {
           const contact = await hubspotClient.crm.contacts.basicApi.getById(
             email,
@@ -131,7 +109,6 @@ module.exports = {
           );
           contactId = contact.id;
           const hubspotId = contactId;
-          // console.log('updating meta.hubspotId');
           await updateMeta(user, hubspotId, profile_updated_count);
         } catch (e) {
           // this is not really an error, it just indicates that the user has never filled a form.
@@ -139,10 +116,6 @@ module.exports = {
             'could not find contact by email. user has never filled a form!',
             e,
           );
-          // await sails.helpers.slack.errorLoggerHelper(
-          //   'Error getting hubspot contact',
-          //   e,
-          // );
         }
       }
 
@@ -154,10 +127,6 @@ module.exports = {
           );
         } catch (e) {
           console.log('error updating contact', e);
-          // await sails.helpers.slack.errorLoggerHelper(
-          //   'Error updating hubspot contact',
-          //   e,
-          // );
         }
       } else {
         try {
@@ -200,7 +169,6 @@ module.exports = {
           err,
         );
       }
-      // console.log('hubspot error', e);
       return exits.success('not ok');
     }
   },
@@ -224,5 +192,3 @@ async function updateMeta(user, hubspotId, profile_updated_count) {
     metaData: JSON.stringify(metaData),
   });
 }
-
-const formatDate = (date) => moment(date).format('YYYY-MM-DD');

--- a/api/helpers/crm/update-user.js
+++ b/api/helpers/crm/update-user.js
@@ -72,7 +72,6 @@ module.exports = {
 
       let contactId;
       let profile_updated_count = 0;
-      console.dir(user, {colors: true, depth: 4})
       if (user.metaData) {
         const metaData = JSON.parse(user.metaData);
         if (metaData.hubspotId) {

--- a/api/models/users/User.js
+++ b/api/models/users/User.js
@@ -228,10 +228,7 @@ module.exports = {
         } else {
           values.isAdmin = false;
         }
-      }
 
-      if (values.email) {
-        // const token = await sails.helpers.strings.random('url-friendly');
         const token = Math.floor(100000 + Math.random() * 900000) + '';
         values.emailConfToken = token;
         values.emailConfTokenDateCreated = Date.now();

--- a/api/util/get-crm-company-object.js
+++ b/api/util/get-crm-company-object.js
@@ -1,0 +1,112 @@
+const moment = require('moment/moment');
+const determineName = async (data, campaignUserId) => {
+  const {
+    name,
+    details
+  } = data
+
+  if (name) {
+    return name;
+  } else if (details?.firstName && details?.lastName) {
+    return `${details.firstName} ${details.lastName}`;
+  }
+
+  const user = await User.findOne({ id: campaignUserId });
+  return await sails.helpers.user.name(user)
+}
+
+const getCRMCompanyObject = async (campaign) => {
+  const { data, isActive, isVerified, dateVerified, isPro } = campaign || {};
+  const {
+    lastStepDate,
+    goals,
+    details,
+    currentStep,
+    aiContent,
+    reportedVoterGoals,
+    p2vStatus,
+    p2vCompleteDate
+  } = data || {};
+  const electionDate = goals?.electionDate || undefined
+  const {
+    zip,
+    party,
+    office,
+    ballotLevel,
+    level,
+    state,
+    pledged,
+    campaignCommittee,
+    otherOffice,
+    district,
+    city,
+    website,
+    runForOffice
+  } = details || {};
+  const name = await determineName(data, campaign.user);
+
+  //UNIX formatted timestamps in milliseconds
+  const electionDateMs = electionDate
+    ? new Date(electionDate).getTime()
+    : undefined;
+
+  const resolvedOffice = office === 'Other' ? otherOffice : office;
+
+  const longState = state
+    ? await sails.helpers.zip.shortToLongState(state)
+    : undefined;
+
+  const verifiedCandidate = isVerified ? 'Yes' : 'No'
+
+  const formattedDate = dateVerified !== null ?
+    moment(new Date(dateVerified)).format('YYYY-MM-DD') : null
+
+  return {
+    properties: {
+      name,
+      candidate_party: party,
+      candidate_office: resolvedOffice,
+      state: longState,
+      candidate_state: longState,
+      candidate_district: district,
+      lifecyclestage: 'customer',
+      city,
+      type: 'CAMPAIGN',
+      last_step: currentStep,
+      last_step_date: lastStepDate || undefined,
+      zip,
+      pledge_status: pledged ? 'yes' : 'no',
+      is_active: !!name,
+      live_candidate: isActive,
+      p2v_complete_date: p2vCompleteDate || undefined,
+      p2v_status: p2vStatus || 'Locked',
+      election_date: electionDateMs,
+      doors_knocked: reportedVoterGoals?.doorKnocking || 0,
+      calls_made: reportedVoterGoals?.calls || 0,
+      online_impressions: reportedVoterGoals?.digital || 0,
+      my_content_pieces_created: aiContent
+        ? Object.keys(data.aiContent).length
+        : 0,
+      filed_candidate: campaignCommittee ? 'yes' : 'no',
+      pro_candidate: isPro ? 'Yes' : 'No',
+      ...(
+        isVerified !== null ?
+          { verified_candidates: verifiedCandidate } :
+          {}
+      ),
+      ...(
+        formattedDate !== null ?
+          { date_verified: formattedDate } :
+          {}
+      ),
+      ...(website ? { website } : {}),
+      ...(level ? { ai_office_level: level } : {}),
+      ...(ballotLevel ? { office_level: ballotLevel } : {}),
+      ...(runForOffice ? { running: runForOffice } : {})
+    },
+  }
+}
+
+module.exports = {
+  getCRMCompanyObject
+}

--- a/config/routes.js
+++ b/config/routes.js
@@ -49,6 +49,7 @@ module.exports.routes = {
   'POST   /api/v1/upload-base64-image': 'user/upload-base64-image',
 
   'GET    /api/v1/admin/candidates': 'admin/candidate/list',
+  'PUT    /api/v1/admin/candidates/mass-crm-companies-refresh': 'admin/mass-crm-companies-refresh',
   'GET    /api/v1/admin/hidden-candidates': 'admin/candidate/hidden-list',
   'GET    /api/v1/admin/users': 'admin/all-users',
   'DELETE    /api/v1/admin/user': 'admin/delete-user',


### PR DESCRIPTION
https://goodparty.atlassian.net/browse/WEB-1842

Creates a PUT route, only accessible to `isAdmin` users, that accepts a body w/ a list of CRM defined fields to be refreshed in the CRM from data within our `campaign` table:
```json
{
    "fields": [
        "pro_candidate",
        "running",
        "verified_candidates",
        "ai_office_level", 
        "office_level",
        "zip",
        "website"
    ]
}
```

If the data has been updated in the columns that map to the given CRM fields, then we add those record updates to a batch update in the CRM.