### PR TITLE
Send Email w/ Retry Abstraction

### DIFF
--- a/api/helpers/mailgun/mailgun-sender.js
+++ b/api/helpers/mailgun/mailgun-sender.js
@@ -1,6 +1,4 @@
-const formData = require('form-data');
-const Mailgun = require('mailgun.js');
-const mailgun = new Mailgun(formData);
+const { sendEmailWithRetry } = require('../../utils/email/sendEmailWithRetry');
 
 module.exports = {
   friendlyName: 'MAIL GUN Sender',
@@ -40,28 +38,18 @@ module.exports = {
 
   fn: async function (inputs, exits) {
     try {
-      const { message, messageHeader, email, name, subject, fromEmail } =
-        inputs;
+      const { message, messageHeader, email, subject, fromEmail } = inputs;
 
-      const mailgunApiKey =
-        sails.config.custom.MAILGUN_API || sails.config.MAILGUN_API;
-
-      const domain = 'mg.goodparty.org';
-      const mg = mailgun.client({ key: mailgunApiKey, username: 'api' });
-
-      // const validFromEmail =
-      //   fromEmail || 'The Good Party <noreply@goodparty.org>';
       const validFromEmail =
         fromEmail || 'GoodParty.org <noreply@goodparty.org>';
 
-      const data = {
+      await sendEmailWithRetry({
         from: validFromEmail,
         to: email,
         subject,
         text: message,
         html: html(message, messageHeader, subject),
-      };
-      const msg = await mg.messages.create(domain, data);
+      });
 
       return exits.success();
     } catch (e) {

--- a/api/helpers/mailgun/mailgun-template-sender.js
+++ b/api/helpers/mailgun/mailgun-template-sender.js
@@ -1,7 +1,4 @@
-const formData = require('form-data');
-const Mailgun = require('mailgun.js');
-const mailgun = new Mailgun(formData);
-
+const { sendEmailWithRetry } = require('../../utils/email/sendEmailWithRetry');
 module.exports = {
   friendlyName: 'Send emails using mailgun helper',
 
@@ -40,11 +37,6 @@ module.exports = {
   fn: async function (inputs, exits) {
     try {
       const { to, subject, template, variables, cc } = inputs;
-      const mailgunApiKey =
-        sails.config.custom.MAILGUN_API || sails.config.MAILGUN_API;
-
-      const domain = 'mg.goodparty.org';
-      const mg = mailgun.client({ key: mailgunApiKey, username: 'api' });
       const data = {
         from: 'GoodParty.org <noreply@goodparty.org>',
         to,
@@ -56,7 +48,7 @@ module.exports = {
         data.cc = cc;
       }
 
-      await mg.messages.create(domain, data);
+      await sendEmailWithRetry(data);
       return exits.success({ message: 'email sent successfully' });
     } catch (e) {
       await sails.helpers.slack.errorLoggerHelper(

--- a/api/utils/email/sendEmailWithRetry.js
+++ b/api/utils/email/sendEmailWithRetry.js
@@ -1,0 +1,33 @@
+const formData = require('form-data');
+const Mailgun = require('mailgun.js');
+const mailgun = new Mailgun(formData);
+const mailgunApiKey =
+  sails.config.custom.MAILGUN_API || sails.config.MAILGUN_API;
+
+const EMAIL_DOMAIN = 'mg.goodparty.org';
+const mg = mailgun.client({ key: mailgunApiKey, username: 'api' });
+
+async function sendEmailWithRetry(emailData, retryCount = 5) {
+  for (let attempt = 0; attempt < retryCount; attempt++) {
+    try {
+      return await mg.messages.create(EMAIL_DOMAIN, emailData);
+    } catch (error) {
+      if (error.status === 429) {
+        // Rate limit exceeded
+        const retryAfter =
+          parseInt(error.response.headers['retry-after'], 10) || 1; // Retry-After header is in seconds
+        console.warn(
+          `Rate limit exceeded. Retrying after ${retryAfter} seconds...`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000)); // Convert to milliseconds
+      } else {
+        throw error; // Rethrow if not rate limit error
+      }
+    }
+  }
+  throw new Error('Exceeded maximum retry attempts');
+}
+
+module.exports = {
+  sendEmailWithRetry,
+};


### PR DESCRIPTION
Abstracts MailGun integration into an isolated, responsible util, and adds a retry mechanism based on `Retry-After` headers if and when we ever receive a `429` response.