### PR TITLE
Fix multi-product bug

### DIFF
--- a/api/controllers/payments/checkout-session/create.js
+++ b/api/controllers/payments/checkout-session/create.js
@@ -1,6 +1,5 @@
-const stripe = require('stripe')(
-  sails.config.custom.stripeSecretKey || sails.config.stripeSecretKey,
-);
+const stripeKey = sails.config.custom.stripeSecretKey || sails.config.stripeSecretKey
+const stripe = require('stripe')(stripeKey);
 
 const appBase = sails.config.custom.appBase || sails.config.appBase;
 
@@ -20,7 +19,12 @@ module.exports = {
   },
 
   fn: async function (inputs, exits) {
-    const prices = await stripe.prices.list();
+    const product = await stripe.products.retrieve(
+      stripeKey?.includes('live')
+        ? 'prod_QCGFVVUhD6q2Jo'
+        : 'prod_QAR4xrqUhyHHqX',
+    );
+    const { default_price: price } = product;
 
     const session = await stripe.checkout.sessions.create({
       billing_address_collection: 'auto',
@@ -28,7 +32,7 @@ module.exports = {
         {
           // We should never have more than 1 price for Pro. But if we do, this
           //  will need to be more intelligent.
-          price: prices.data[0].id,
+          price,
           quantity: 1,
         },
       ],


### PR DESCRIPTION
Stripe's CLI tool likes to create products when you run stripe trigger 'checkout.session.complete' and doesn't clean up after itself for some reason.. so there's a ton of other products in our testing env now.. and so that bit of code is grabbing the wrong product and then failing..

This fixes that by grabbing the specific product depending on the env `stripeKey`