### PR TITLE
WEB-2811: fix key for digital ads count in prompt response

### DIFF
--- a/api/helpers/ai/prompt-replace.js
+++ b/api/helpers/ai/prompt-replace.js
@@ -242,7 +242,7 @@ module.exports = {
           allTime: {
             total: 0,
             doorKnocking: 0,
-            digital: 0,
+            digitalAds: 0,
             calls: 0,
             yardSigns: 0,
             events: 0,
@@ -252,7 +252,7 @@ module.exports = {
           thisWeek: {
             total: 0,
             doorKnocking: 0,
-            digital: 0,
+            digitalAds: 0,
             calls: 0,
             yardSigns: 0,
             events: 0,
@@ -262,7 +262,7 @@ module.exports = {
           lastWeek: {
             total: 0,
             doorKnocking: 0,
-            digital: 0,
+            digitalAds: 0,
             calls: 0,
             yardSigns: 0,
             events: 0,


### PR DESCRIPTION
This changes key for summing Digital Ads update history in the `prompt-replace` helper. It was expected Digital Ad CampaignUpdateHistory items to have a type of `digital` when they are actually `digitalAds`