### PR TITLE
WEB-3086: "Who would you like to text?" includes a free text field

### DIFF
--- a/api/controllers/voterData/voterFile/schedule.js
+++ b/api/controllers/voterData/voterFile/schedule.js
@@ -80,7 +80,13 @@ module.exports = {
       };
 
       const formattedAudience = Object.entries(audience)
-        .map(([key, value]) => `￮ ${key}: ${value ? '✅ Yes' : '❌ No'}`)
+        .map(([key, value]) => {
+          if (typeof value === 'boolean') {
+            return `￮ ${key}: ${value ? '✅ Yes' : '❌ No'}`;
+          } else {
+            return `￮ ${key}: ${value}`;
+          }
+        })
         .join('\n');
 
       await sails.helpers.slack.slackHelper(


### PR DESCRIPTION
Small change to allow displaying the new `audience_request` text field in a text/phone campaign schedule slack message