### PR TITLE
WEB-3130, WEB-3118: Candidate map query fixes

### DIFF
--- a/api/controllers/campaign/list-map.js
+++ b/api/controllers/campaign/list-map.js
@@ -72,7 +72,7 @@ module.exports = {
       let whereClauses = `WHERE c."user" IS NOT NULL AND c."isDemo" = false AND c."isActive" = true`;
 
       if (partyFilter) {
-        whereClauses += ` AND c.details->>'party' = '${partyFilter}'`;
+        whereClauses += ` AND LOWER(c.details->>'party') LIKE '${partyFilter}%'`;
       }
 
       if (stateFilter) {
@@ -84,7 +84,7 @@ module.exports = {
       }
 
       if (resultsFilter) {
-        whereClauses += ` AND c."didWin" = true`; // "didWin" is properly quoted
+        whereClauses += ` AND (c."didWin" = true OR c.data->'hubSpotUpdates'->>'election_results' = 'Won General')`; // "didWin" is properly quoted
       }
 
       if (officeFilter) {


### PR DESCRIPTION
Contains query fixes for two bug tickets
- Updated the `result` filter to check `campaign.hubSpotUpdates.election_results` along with `campaign.didWin`
[WEB-3130](https://goodparty.atlassian.net/browse/WEB-3130): [Usersnap] only showing 86 winners, we have more than that
- Updated the `party` filter to use a LIKE to capture more results, e.g. `forward` and `Forward Party`
[WEB-3118](https://goodparty.atlassian.net/browse/WEB-3118): [Usersnap] Map says we have No Results for FWD Party candidates. I don't beli...

[WEB-3130]: https://goodparty.atlassian.net/browse/WEB-3130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-3118]: https://goodparty.atlassian.net/browse/WEB-3118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ