### PR TITLE
WEB-3185: Enhancement: Include User message in Chat Bot Feedback

### DIFF
--- a/api/controllers/campaign/ai/chat/feedback.js
+++ b/api/controllers/campaign/ai/chat/feedback.js
@@ -53,18 +53,20 @@ module.exports = {
         },
       });
 
+      const lastMsgIndex = aiChat?.data?.messages.length - 1;
+      const slackBlocks = buildSlackBlocks(
+        type,
+        user.email,
+        threadId,
+        message,
+        aiChat?.data?.messages[lastMsgIndex - 1]?.content,
+        aiChat?.data?.messages[lastMsgIndex]?.content,
+      );
+
       await sails.helpers.slack.slackHelper(
-        {
-          title: `${type} feedback on AI Chat thread`,
-          body: `${type} feedback on AI Chat thread
-          User: ${user.email}
-          ${message ? `Message: ${message}` : ''}
-          Thread ID: ${threadId}
-          Last Message on thread: ${
-            aiChat?.data?.messages[aiChat?.data?.messages.length - 1]?.content
-          }`,
-        },
+        slackBlocks,
         'user-feedback',
+        false,
       );
 
       return exits.success({ message: 'ok' });
@@ -81,3 +83,134 @@ module.exports = {
     }
   },
 };
+
+function buildSlackBlocks(
+  type,
+  email,
+  threadId,
+  userMessage,
+  userPrompt,
+  lastThreadMessage,
+) {
+  const title = `${
+    type.charAt(0).toUpperCase() + type.slice(1)
+  } feedback on AI Chat thread`;
+
+  return {
+    blocks: [
+      {
+        type: 'header',
+        text: {
+          type: 'plain_text',
+          text: `💬 ${title}`,
+          emoji: true,
+        },
+      },
+      {
+        type: 'rich_text',
+        elements: [
+          {
+            type: 'rich_text_list',
+            style: 'bullet',
+            elements: [
+              {
+                type: 'rich_text_section',
+                elements: [
+                  {
+                    type: 'text',
+                    text: 'User: ',
+                    style: {
+                      bold: true,
+                    },
+                  },
+                  {
+                    type: 'text',
+                    text: String(email),
+                  },
+                ],
+              },
+              {
+                type: 'rich_text_section',
+                elements: [
+                  {
+                    type: 'text',
+                    text: 'Message: ',
+                    style: {
+                      bold: true,
+                    },
+                  },
+                  {
+                    type: 'text',
+                    text: String(userMessage),
+                  },
+                ],
+              },
+              {
+                type: 'rich_text_section',
+                elements: [
+                  {
+                    type: 'text',
+                    text: 'Thread ID: ',
+                    style: {
+                      bold: true,
+                    },
+                  },
+                  {
+                    type: 'text',
+                    text: String(threadId),
+                  },
+                ],
+              },
+              {
+                type: 'rich_text_section',
+                elements: [
+                  {
+                    type: 'text',
+                    text: 'User Prompt: ',
+                    style: {
+                      bold: true,
+                    },
+                  },
+                  {
+                    type: 'text',
+                    text: String(userPrompt),
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: 'rich_text_section',
+            elements: [
+              {
+                type: 'text',
+                text: '\n\n',
+              },
+            ],
+          },
+          {
+            type: 'rich_text_section',
+            elements: [
+              {
+                type: 'text',
+                text: ' Last Message on Thread:',
+                style: {
+                  bold: true,
+                },
+              },
+            ],
+          },
+          {
+            type: 'rich_text_preformatted',
+            elements: [
+              {
+                type: 'text',
+                text: lastThreadMessage,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/api/controllers/campaign/ai/chat/feedback.js
+++ b/api/controllers/campaign/ai/chat/feedback.js
@@ -129,22 +129,24 @@ function buildSlackBlocks(
                   },
                 ],
               },
-              {
-                type: 'rich_text_section',
-                elements: [
-                  {
-                    type: 'text',
-                    text: 'Message: ',
-                    style: {
-                      bold: true,
-                    },
-                  },
-                  {
-                    type: 'text',
-                    text: String(userMessage),
-                  },
-                ],
-              },
+              userMessage
+                ? {
+                    type: 'rich_text_section',
+                    elements: [
+                      {
+                        type: 'text',
+                        text: 'Message: ',
+                        style: {
+                          bold: true,
+                        },
+                      },
+                      {
+                        type: 'text',
+                        text: String(userMessage),
+                      },
+                    ],
+                  }
+                : undefined,
               {
                 type: 'rich_text_section',
                 elements: [
@@ -177,7 +179,7 @@ function buildSlackBlocks(
                   },
                 ],
               },
-            ],
+            ].filter((elem) => elem !== undefined),
           },
           {
             type: 'rich_text_section',


### PR DESCRIPTION
Adds the user's prompt before the message they are submitting feedback for to the slack message in `#bot-ai-chat-feedback`. Also added a little more formatting to the slack message for readability.


<img width="1272" alt="Screenshot 2024-11-07 at 3 23 10 PM" src="https://github.com/user-attachments/assets/d32257c4-4f9e-4d7b-b6e9-6e7905e51508">

<img width="1230" alt="Screenshot 2024-11-07 at 3 23 14 PM" src="https://github.com/user-attachments/assets/142bdc56-ff24-4868-a5df-4728a8ebd123">
