### PR TITLE
WEB-3349: make candidate map election_result query case insensitive

### DIFF
--- a/api/controllers/campaign/list-map-count.js
+++ b/api/controllers/campaign/list-map-count.js
@@ -38,7 +38,9 @@ module.exports = {
       }
 
       if (results) {
-        whereClauses += ` AND (c."didWin" = true OR c.data->'hubSpotUpdates'->>'election_results' = 'Won General' OR c.data->'hubSpotUpdates'->>'primary_election_result' = 'Won Primary')`; // "didWin" is properly quoted
+        whereClauses += ` AND (c."didWin" = true 
+          OR LOWER(c.data->'hubSpotUpdates'->>'election_results') = 'won general' 
+          OR LOWER(c.data->'hubSpotUpdates'->>'primary_election_result') = 'won primary')`; // "didWin" is properly quoted
       } else if (isProd) {
         whereClauses += ` AND c.data->'hubSpotUpdates'->>'verified_candidates' = 'Yes'`;
       }

--- a/api/controllers/campaign/list-map.js
+++ b/api/controllers/campaign/list-map.js
@@ -73,7 +73,9 @@ module.exports = {
       }
 
       if (resultsFilter) {
-        whereClauses += ` AND (c."didWin" = true OR c.data->'hubSpotUpdates'->>'election_results' = 'Won General' OR c.data->'hubSpotUpdates'->>'primary_election_result' = 'Won Primary')`; // "didWin" is properly quoted
+        whereClauses += ` AND (c."didWin" = true 
+          OR LOWER(c.data->'hubSpotUpdates'->>'election_results') = 'won general' 
+          OR LOWER(c.data->'hubSpotUpdates'->>'primary_election_result') = 'won primary')`; // "didWin" is properly quoted
       } else if (isProd) {
         whereClauses += ` AND c.data->'hubSpotUpdates'->>'verified_candidates' = 'Yes'`;
       }

--- a/api/controllers/seed/campaigns.js
+++ b/api/controllers/seed/campaigns.js
@@ -12,6 +12,14 @@ const PARTIES = [
 ];
 const LEVELS = ['LOCAL', 'CITY', 'COUNTY', 'STATE', 'FEDERAL'];
 const P2V_STATUS = ['Waiting', 'Complete', 'Failed'];
+const OFFICES = [
+  'Representative',
+  'Governor',
+  'Senator',
+  'City Council',
+  'Commissioner',
+  'Sheriff',
+];
 
 function randomItem(arr) {
   return arr[Math.floor(Math.random() * arr.length)];
@@ -87,6 +95,21 @@ module.exports = {
                 data: {
                   slug,
                   currentStep: 'onboarding-complete',
+                  hubSpotUpdates: {
+                    election_results: randomItem([
+                      'Won General',
+                      'won general',
+                      'Lost General',
+                      null,
+                    ]),
+                    primary_election_result: randomItem([
+                      'Won Primary',
+                      'won primary',
+                      'Lost Primary',
+                      null,
+                    ]),
+                    // TODO: add more hubspot fields
+                  },
                 },
                 isDemo: false,
                 isActive: true,
@@ -100,9 +123,7 @@ module.exports = {
                   geoLocation: { ...location },
                   state: state.key,
                   office: 'Other',
-                  otherOffice: `${
-                    state.key
-                  } ${level.toLowerCase()} Representative`,
+                  otherOffice: randomItem(OFFICES),
                   level,
                   ballotLevel: level,
                   hasPrimary: false,
@@ -126,11 +147,10 @@ module.exports = {
                 { campaign: campaign.id },
                 {
                   campaign: campaign.id,
-                  // TODO: add more values
+                  // TODO: add more p2v values
                   data: { p2vStatus: randomItem(P2V_STATUS) },
                 },
-              )
-              .then((p2v) =>
+              ).then((p2v) =>
                 Campaign.updateOne({ id: campaign.id }).set({
                   pathToVictory: p2v.id,
                 }),


### PR DESCRIPTION
A winning campaign was getting missed in the map query because it had a `election_results` value of `won general` instead of capitalized `Won General`. Updated the query to be case insensitive for the  `election_results` and `primary_election_result`  fields