### PR TITLE
WEB-3329: Allow set password email flow for sales role users

### DIFF
--- a/api/controllers/entrance/reset-password.js
+++ b/api/controllers/entrance/reset-password.js
@@ -1,3 +1,5 @@
+const { USER_ROLES } = require('../../models/users/User');
+
 module.exports = {
   friendlyName: 'Update password and login',
 
@@ -84,7 +86,7 @@ module.exports = {
 
       console.log('reset4');
 
-      if (adminCreate) {
+      if (adminCreate && user.role !== USER_ROLES.SALES) {
         // check if the campaign attached to this user is marked as created by admin
         const campaign = await sails.helpers.campaign.byUser(user.id);
         if (campaign.data.createdBy !== 'admin') {


### PR DESCRIPTION
- Updates `admin-create-email` route to be able send a set password email for a Sales user
