### PR TITLE
WEB-3348: Hubspot campaign data getting out of sync

### DIFF
--- a/api/helpers/crm/get-company.js
+++ b/api/helpers/crm/get-company.js
@@ -1,4 +1,7 @@
-const { hubspotClient } = require('../../utils/crm/crmClientSingleton');
+const {
+  hubspotClient,
+  hubspotProperties,
+} = require('../../utils/crm/crmClientSingleton');
 module.exports = {
   inputs: {
     campaign: {
@@ -24,28 +27,9 @@ module.exports = {
 
       const hubspotId = data.hubspotId;
 
-      const properties = [
-        'past_candidate',
-        'incumbent',
-        'candidate_experience_level',
-        'final_viability_rating',
-        'primary_election_result',
-        'election_results',
-        'professional_experience',
-        'p2p_campaigns',
-        'p2p_sent',
-        'confirmed_self_filer',
-        'verified_candidates',
-        'date_verified',
-        'pro_candidate',
-        'filing_deadline',
-        'opponents',
-        'hubspot_owner_id',
-      ];
-
       const company = await hubspotClient.crm.companies.basicApi.getById(
         hubspotId,
-        properties,
+        hubspotProperties,
       );
 
       return exits.success(company);

--- a/api/utils/crm/crmClientSingleton.js
+++ b/api/utils/crm/crmClientSingleton.js
@@ -8,6 +8,27 @@ const hubSpotToken =
 const hubspotClient =
   hubSpotToken && new hubspot.Client({ accessToken: hubSpotToken });
 
+const hubspotProperties = [
+  'past_candidate',
+  'incumbent',
+  'candidate_experience_level',
+  'final_viability_rating',
+  'primary_election_result',
+  'election_results',
+  'professional_experience',
+  'p2p_campaigns',
+  'p2p_sent',
+  'confirmed_self_filer',
+  'verified_candidates',
+  'date_verified',
+  'pro_candidate',
+  'filing_deadline',
+  'opponents',
+  'hubspot_owner_id',
+  'office_type',
+];
+
 module.exports = {
   hubspotClient,
+  hubspotProperties,
 };

--- a/api/utils/objects.js
+++ b/api/utils/objects.js
@@ -1,0 +1,22 @@
+/**
+ * helper to get an object from a subset of another object's keys
+ * @param {object} obj Source object
+ * @param {string[]} keys Array of keys to pick
+ * @returns {object}
+ */
+function pick(obj, keys) {
+  if (typeof obj !== 'object' || obj === null || !Array.isArray(keys)) {
+    throw new Error('invalid args');
+  }
+
+  return (
+    keys
+      .filter((key) => key in obj)
+      // eslint-disable-next-line no-return-assign
+      .reduce((obj2, key) => ((obj2[key] = obj[key]), obj2), {})
+  );
+}
+
+module.exports = {
+  pick,
+};


### PR DESCRIPTION
Updates the `crm/sync` endpoint to accept a `campaignId` param to run a sync for a specific campaign, and a `resync` param to update hubspot properties for campaigns that already have them set.