### PR TITLE
WEB-3386: remove primary wins from win count

### DIFF
--- a/api/controllers/campaign/list-map-count.js
+++ b/api/controllers/campaign/list-map-count.js
@@ -38,9 +38,10 @@ module.exports = {
       }
 
       if (results) {
+        // "didWin" is properly quoted
         whereClauses += ` AND (c."didWin" = true 
-          OR LOWER(c.data->'hubSpotUpdates'->>'election_results') = 'won general' 
-          OR LOWER(c.data->'hubSpotUpdates'->>'primary_election_result') = 'won primary')`; // "didWin" is properly quoted
+          OR LOWER(c.data->'hubSpotUpdates'->>'election_results') = 'won general')`;
+        // OR LOWER(c.data->'hubSpotUpdates'->>'primary_election_result') = 'won primary')`;
       } else if (isProd) {
         whereClauses += ` AND c.data->'hubSpotUpdates'->>'verified_candidates' = 'Yes'`;
       }

--- a/api/controllers/campaign/list-map.js
+++ b/api/controllers/campaign/list-map.js
@@ -73,9 +73,10 @@ module.exports = {
       }
 
       if (resultsFilter) {
+        // "didWin" is properly quoted
         whereClauses += ` AND (c."didWin" = true 
-          OR LOWER(c.data->'hubSpotUpdates'->>'election_results') = 'won general' 
-          OR LOWER(c.data->'hubSpotUpdates'->>'primary_election_result') = 'won primary')`; // "didWin" is properly quoted
+          OR LOWER(c.data->'hubSpotUpdates'->>'election_results') = 'won general')`;
+        // OR LOWER(c.data->'hubSpotUpdates'->>'primary_election_result') = 'won primary')`;
       } else if (isProd) {
         whereClauses += ` AND c.data->'hubSpotUpdates'->>'verified_candidates' = 'Yes'`;
       }


### PR DESCRIPTION
Updated `list-map` and `list-map-count` queries to not filter for primary winners